### PR TITLE
Make iter_set_bits & iter_unset_bits take range arguments.

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -1,0 +1,57 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of the Rust distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::{RangeFull, Range, RangeTo, RangeFrom};
+pub use std::collections::Bound::{self, Excluded, Included, Unbounded};
+
+pub trait RangeBounds<T: ?Sized> {
+    fn start(&self) -> Bound<&T>;
+    fn end(&self) -> Bound<&T>;
+}
+
+impl<T: ?Sized> RangeBounds<T> for RangeFull {
+    fn start(&self) -> Bound<&T> {
+        Unbounded
+    }
+
+    fn end(&self) -> Bound<&T> {
+        Unbounded
+    }
+}
+
+impl<T> RangeBounds<T> for RangeFrom<T> {
+    fn start(&self) -> Bound<&T> {
+        Included(&self.start)
+    }
+
+    fn end(&self) -> Bound<&T> {
+        Unbounded
+    }
+}
+
+impl<T> RangeBounds<T> for RangeTo<T> {
+    fn start(&self) -> Bound<&T> {
+        Unbounded
+    }
+
+    fn end(&self) -> Bound<&T> {
+        Excluded(&self.end)
+    }
+}
+
+impl<T> RangeBounds<T> for Range<T> {
+    fn start(&self) -> Bound<&T> {
+        Included(&self.start)
+    }
+
+    fn end(&self) -> Bound<&T> {
+        Excluded(&self.end)
+    }
+}


### PR DESCRIPTION
We will never be able to take a slice of a Vob, because a slice needs to be a (byte aligned) pointer. That means that the previous definitions of `iter_set_bits` and `iter_unset_bits` were only useful if you wanted to find either a) every set/unset bit b) the first N set/unset bits.

In particular, you could not say things like "find me all set/unset bits between positions 50 and 100". `iter_set_bits().skip(50).take(50)` might seem like it would work, but this would take the first 50 set bits, none of which might be between positions 50 and 100! Instead, one had to manually check each bit which is very slow.

This PR changes that: iter_set_bits and iter_unset_bits now take a range, like "drain". You can say things like `iter_set_bits(..)` or `iter_set_bits(10..)` and so on.

The bad news is that `RangeArgument` is unstable; that means we have to have our own version of the API in this crate. Since it's expected that Rust will eventually call this `RangeBounds`, I've chosen to use that terminology. This is a temporaryish hack until this feature is eventually stabilised in Rust, but it means that we can still run things on stable in the meantime.