### PR TITLE
As feared, crates.io still doesn't know about UPL-1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ repository = "https://github.com/softdevteam/vob/"
 version = "1.0.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
-license = "Apache-2.0 OR MIT OR UPL-1.0"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
 categories = ["data-structures"]
 
 [dependencies]


### PR DESCRIPTION
Even though the actual license is Apache/MIT/UPL, we pretend to crates.io that it's just Apache/MIT. When, eventually, crates.io picks up the UPL, we can add that back in as another "OR". But I think simply dropping it from Cargo.toml is better than having the license show up as "non-standard".