### PR TITLE
Reference the correct BitVec crate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Vob is a "vector of bits": a sequence of bits which exposes a `Vec`-like
 interface. Whereas `Vec<bool>` requires 1 byte of storage per bit, `Vob`
 requires only 1 bit of storage per bit. `Vob` is broadly
-similar to [BitVec](https://crates.io/crates/bitvec-rs), but has an API more
+similar to [BitVec](https://crates.io/crates/bit-vec), but has an API more
 closely aligned to `Vec<bool>` and allows non-32-bit backing storage. On 64-bit
 systems this can lead to a substantial performance increase, particularly
 when functions such as


### PR DESCRIPTION
I got this right in wrong place and wrong in another. Oops.