### PR TITLE
Add Serde support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vob"
 description = "Vector of Bits with Vec-like API and usize backing storage"
 repository = "https://github.com/softdevteam/vob/"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
@@ -12,3 +12,4 @@ categories = ["data-structures"]
 
 [dependencies]
 num-traits = "0.2.1"
+serde = { version="1.0", features=["derive"], optional=true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 //! The main documentation for this crate can be found in the [`Vob`](struct.Vob.html) struct.
 
 extern crate num_traits;
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
 
 use std::cmp::{min, PartialEq};
 use std::fmt;
@@ -101,6 +104,7 @@ use range::{Included, Excluded, RangeBounds, Unbounded};
 /// (keeping the length unchanged). The same effect as `BitVec`'s `clear` can be achieved by using
 /// `Vob`'s [`set_all(false)`](struct.Vob.html#method.set_all) function.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Vob<T=usize> {
     /// How many bits are stored in this Vob?
     len: usize,


### PR DESCRIPTION
This is enabled by an optional "serde" feature. It means that a program such as:

```rust
extern crate serde_json;
#[macro_use]
extern crate vob;

use vob::Vob;

fn main() {
    let mut v = vob![true, false, true];
    let serialized = serde_json::to_string(&v).unwrap();
    println!("{}", serialized);

    v.push(false);

    let deserialized: Vob = serde_json::from_str(&serialized).unwrap();
    println!("{:?}", deserialized);
}
```

prints out:

```
{"len":3,"vec":[5]}
Vob[101]
```

Addresses https://github.com/softdevteam/vob/issues/9