### PR TITLE
Add a from_bytes function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vob"
 description = "Vector of Bits with Vec-like API and usize backing storage"
 repository = "https://github.com/softdevteam/vob/"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about


### PR DESCRIPTION
The API (with the reversing of bits) is, intentionally, exactly the same as BitVec's. Our implementation is quite a bit different and, hopefully, a bit simpler.

Should address https://github.com/softdevteam/vob/issues/11 -- @thomwiggers is this the functionality you were asking for?