### PR TITLE
Allow accessing storage mutably

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,14 @@
 language: rust
-rust: stable
+
+matrix:
+  include:
+    - rust: nightly
+      env: FEATURES=unsafe_internals
+    - rust: nightly
+      env: FEATURES=''
+    - rust: stable
+    - rust: beta
+
+script:
+  - cargo build --features "$FEATURES"
+  - "[ \"$TRAVIS_RUST_VERSION\" != 'nightly' ] ||  cargo bench --features \"$FEATURES\""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version="1.0", features=["derive"], optional=true }
 
 [dev-dependencies]
 rand = "0.5"
+
+[features]
+unsafe_internals = []


### PR DESCRIPTION
This allows me to directly write blocks as I'm reading them from my matrices' backing storage,
which are already in the right bit order.

I've marked it as unsafe, as it allows to invalidate the invariants of `Vob`.