### PR TITLE
start/end are now start_bounds/end_bounds in Rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,12 +457,12 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     fn process_range<R>(&self, range: R) -> Range<usize>
         where R: RangeBounds<usize>
     {
-        let start = match range.start() {
+        let start = match range.start_bound() {
             Included(t) => min(*t, self.len),
             Excluded(t) => min(*t + 1, self.len),
             Unbounded => 0
         };
-        let end = match range.end() {
+        let end = match range.end_bound() {
             Included(t) => min(*t + 1, self.len()),
             Excluded(t) => min(*t, self.len()),
             Unbounded => self.len

--- a/src/range.rs
+++ b/src/range.rs
@@ -12,46 +12,46 @@ use std::ops::{RangeFull, Range, RangeTo, RangeFrom};
 pub use std::collections::Bound::{self, Excluded, Included, Unbounded};
 
 pub trait RangeBounds<T: ?Sized> {
-    fn start(&self) -> Bound<&T>;
-    fn end(&self) -> Bound<&T>;
+    fn start_bound(&self) -> Bound<&T>;
+    fn end_bound(&self) -> Bound<&T>;
 }
 
 impl<T: ?Sized> RangeBounds<T> for RangeFull {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
 
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Unbounded
     }
 }
 
 impl<T> RangeBounds<T> for RangeFrom<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(&self.start)
     }
 
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Unbounded
     }
 }
 
 impl<T> RangeBounds<T> for RangeTo<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
 
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Excluded(&self.end)
     }
 }
 
 impl<T> RangeBounds<T> for Range<T> {
-    fn start(&self) -> Bound<&T> {
+    fn start_bound(&self) -> Bound<&T> {
         Included(&self.start)
     }
 
-    fn end(&self) -> Bound<&T> {
+    fn end_bound(&self) -> Bound<&T> {
         Excluded(&self.end)
     }
 }


### PR DESCRIPTION
See https://github.com/rust-lang/rust/commit/07c415c2154f29d6dce8da0154ef41c8a5497fbf

I assume this is likely to be in Rust 1.27, so changing our implementation of it in preparation is a simple way of getting us ready. Assuming this does make it into 1.27, we can delete our version of range entirely.