### PR TITLE
Add extend_from_vob

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["data-structures"]
 [dependencies]
 num-traits = "0.2.1"
 serde = { version="1.0", features=["derive"], optional=true }
+
+[dev-dependencies]
+rand = "0.5"

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -1,0 +1,51 @@
+#![feature(test)]
+
+#[macro_use]
+extern crate vob;
+extern crate test;
+
+use test::Bencher;
+use vob::*;
+
+const N: usize = 100000;
+
+#[bench]
+fn empty(b: &mut Bencher) {
+    b.iter(|| Vob::with_capacity(N));
+}
+
+#[bench]
+fn extend(b: &mut Bencher) {
+    // first initialise the source vector to drain
+    let mut source = Vob::with_capacity(N);
+    source.extend((0..N).map(|i| i % 2 == 0));
+
+    b.iter(|| {
+        let mut vector = Vob::with_capacity(N);
+        vector.extend(source.iter())
+    });
+}
+
+#[bench]
+fn extend_vob_aligned(b: &mut Bencher) {
+    // first initialise the source vector to drain
+    let mut source = Vob::with_capacity(N);
+    source.extend((0..N).map(|i| i % 2 == 0));
+
+    b.iter(|| {
+        let mut vector = Vob::with_capacity(N);
+        vector.extend_from_vob(&source)
+    });
+}
+
+#[bench]
+fn extend_vob_not_aligned(b: &mut Bencher) {
+    // first initialise the source vector to drain
+    let mut source = Vob::with_capacity(N);
+    source.extend((0..N).map(|i| i % 2 == 0));
+
+    b.iter(|| {
+        let mut vector = vob![true];
+        vector.extend_from_vob(&source)
+    });
+}


### PR DESCRIPTION
Because this allows to use the assumptions in Vob, it's over a 100 times faster

Includes benchmarks

    running 4 tests
    test empty                  ... bench:          28 ns/iter (+/- 2)
    test extend                 ... bench:     469,014 ns/iter (+/- 60,205)
    test extend_vob_aligned     ... bench:         857 ns/iter (+/- 61)
    test extend_vob_not_aligned ... bench:       4,793 ns/iter (+/- 277)