### PR TITLE
Use reverse_bits intrinsic when supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: rust
 
-matrix:
-  include:
-    - rust: nightly
-      env: FEATURES=unsafe_internals
-    - rust: nightly
-      env: FEATURES=''
-    - rust: stable
-    - rust: beta
+rust:
+  - stable
+  - nightly
+env:
+  - FEATURES=''
+  - FEATURES='unsafe_internals'
 
 before_script:
   - rustup component add rustfmt-preview

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 license = "Apache-2.0 OR MIT"
 categories = ["data-structures"]
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [dependencies]
 num-traits = "0.2.1"
 serde = { version="1.0", features=["derive"], optional=true }

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -101,3 +101,12 @@ fn and(bench: &mut Bencher) {
         a.and(&b);
     });
 }
+
+#[bench]
+fn from_bytes(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let mut source = [0u8; 1024];
+    rng.fill(&mut source);
+
+    b.iter(|| Vob::from_bytes(&source));
+}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+extern crate rustc_version;
+
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Set features depending on channel
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=nightly");
+        // Nightly supports https://github.com/rust-lang/rust/issues/48763
+        println!("cargo:rustc-cfg=reverse_bits");
+    }
+}


### PR DESCRIPTION
This adds a new feature that allows to conditionally use the new
reverse_bits feature in Rust.