### PR TITLE
Run cargo fmt as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ matrix:
     - rust: stable
     - rust: beta
 
+before_script:
+  - rustup component add rustfmt-preview
+
 script:
   - cargo build --tests --features "$FEATURES"
   - cargo test --features "$FEATURES"
   - "[ \"$TRAVIS_RUST_VERSION\" != 'nightly' ] ||  cargo bench --features \"$FEATURES\""
+  - "[ \"$TRAVIS_RUST_VERSION\" != 'nightly' ] ||  cargo fmt -- --check"
+
+cache: cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,9 @@ impl Vob<usize> {
     /// }
     /// ```
     pub fn from_bytes(slice: &[u8]) -> Vob<usize> {
-        let mut v = Vob::with_capacity(slice.len().checked_mul(8).expect("Overflow detected"));
-        for i in 0..blocks_required::<usize>(slice.len() * 8) {
+        let new_len = slice.len().checked_mul(8).expect("Overflow detected");
+        let mut v = Vob::with_capacity(new_len);
+        for i in 0..blocks_required::<usize>(new_len) {
             let mut w = usize::zero();
             for j in 0..bytes_per_block::<usize>() {
                 let off = i * bytes_per_block::<usize>() + j;
@@ -196,7 +197,7 @@ impl Vob<usize> {
             }
             v.vec.push(w);
         }
-        v.len = slice.len() * 8;
+        v.len = new_len;
         v
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,13 @@ use std::mem::{replace, size_of};
 use std::ops::{Index, Range};
 use std::slice;
 
-use num_traits::{PrimInt, One, Zero};
+use num_traits::{One, PrimInt, Zero};
 
 // Whilst we wait for https://github.com/rust-lang/rust/issues/30877 to become stable, we can't use
 // RangeBounds and friends. We therefore have to implement a subset of the expected functionality
 // ourselves.
 mod range;
-use range::{Included, Excluded, RangeBounds, Unbounded};
+use range::{Excluded, Included, RangeBounds, Unbounded};
 
 /// A Vob is a "vector of bits": a sequence of bits which exposes a `Vec`-like interface. Whereas
 /// `Vec<bool>` requires 1 byte of storage per bit, `Vob` requires only 1 bit of storage per bit.
@@ -107,14 +107,14 @@ use range::{Included, Excluded, RangeBounds, Unbounded};
 /// `Vob`'s [`set_all(false)`](struct.Vob.html#method.set_all) function.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Vob<T=usize> {
+pub struct Vob<T = usize> {
     /// How many bits are stored in this Vob?
     len: usize,
     /// The underlying storage. We refer to a single instance of `T` as a block. Since the storage
     /// consists of (potentially multiple-byte) blocks, there may be "unused" bits in the final
     /// block. We guarantee that, at all points visible to the user, the "unused" bits are set to
     /// 0.
-    vec: Vec<T>
+    vec: Vec<T>,
 }
 
 // In an ideal world, Rust's type defaults would allow us to fold the two impl blocks into one and
@@ -136,7 +136,7 @@ impl Vob<usize> {
     pub fn with_capacity(capacity: usize) -> Vob<usize> {
         Vob {
             len: 0,
-            vec: Vec::with_capacity(blocks_required::<usize>(capacity))
+            vec: Vec::with_capacity(blocks_required::<usize>(capacity)),
         }
     }
 
@@ -174,9 +174,7 @@ impl Vob<usize> {
     /// }
     /// ```
     pub fn from_bytes(slice: &[u8]) -> Vob<usize> {
-        let mut v = Vob::with_capacity(slice.len()
-                                            .checked_mul(8)
-                                            .expect("Overflow detected"));
+        let mut v = Vob::with_capacity(slice.len().checked_mul(8).expect("Overflow detected"));
         for i in 0..blocks_required::<usize>(slice.len() * 8) {
             let mut w = usize::zero();
             for j in 0..bytes_per_block::<usize>() {
@@ -217,7 +215,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     pub fn new_with_storage_type(capacity: usize) -> Vob<T> {
         Vob {
             len: 0,
-            vec: Vec::with_capacity(capacity)
+            vec: Vec::with_capacity(capacity),
         }
     }
 
@@ -453,11 +451,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         let msk = T::one() << (index % bits_per_block::<T>());
         let off = block_offset::<T>(index);
         let old_v = self.vec[off];
-        let new_v = if value {
-                        old_v | msk
-                    } else {
-                        old_v & !msk
-                    };
+        let new_v = if value { old_v | msk } else { old_v & !msk };
         if new_v != old_v {
             self.vec[off] = new_v;
             Some(true)
@@ -482,25 +476,26 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     pub fn iter(&self) -> Iter<T> {
         Iter {
             vob: self,
-            range: 0..self.len
+            range: 0..self.len,
         }
     }
 
     /// Convert a `RangeBounds` into a `Range`, taking into account this `Vob`'s length.
     fn process_range<R>(&self, range: R) -> Range<usize>
-        where R: RangeBounds<usize>
+    where
+        R: RangeBounds<usize>,
     {
         let start = match range.start_bound() {
             Included(t) => min(*t, self.len),
             Excluded(t) => min(*t + 1, self.len),
-            Unbounded => 0
+            Unbounded => 0,
         };
         let end = match range.end_bound() {
             Included(t) => min(*t + 1, self.len()),
             Excluded(t) => min(*t, self.len()),
-            Unbounded => self.len
+            Unbounded => self.len,
         };
-        Range{start, end}
+        Range { start, end }
     }
 
     /// Returns an iterator which efficiently produces the index of each set bit in the specified
@@ -518,11 +513,12 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// assert_eq!(iterator.next(), None);
     /// ```
     pub fn iter_set_bits<R>(&self, range: R) -> IterSetBits<T>
-        where R: RangeBounds<usize>
+    where
+        R: RangeBounds<usize>,
     {
         IterSetBits {
             vob: self,
-            range: self.process_range(range)
+            range: self.process_range(range),
         }
     }
 
@@ -541,11 +537,12 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// assert_eq!(iterator.next(), None);
     /// ```
     pub fn iter_unset_bits<R>(&self, range: R) -> IterUnsetBits<T>
-        where R: RangeBounds<usize>
+    where
+        R: RangeBounds<usize>,
     {
         IterUnsetBits {
             vob: self,
-            range: self.process_range(range)
+            range: self.process_range(range),
         }
     }
 
@@ -561,7 +558,9 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// assert_eq!(v2.iter_storage().last(), Some(1));
     /// ```
     pub fn iter_storage(&self) -> StorageIter<T> {
-        StorageIter{iter: self.vec.iter()}
+        StorageIter {
+            iter: self.vec.iter(),
+        }
     }
 
     /// Resizes the Vob in-place so that `len` is equal to `new_len`.
@@ -583,7 +582,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     pub fn resize(&mut self, new_len: usize, value: bool) {
         if new_len <= self.len {
             self.truncate(new_len);
-            return
+            return;
         }
         if value && self.len > 0 {
             // If we're resizing with trues, we need to extend the last block with true bits. We
@@ -592,11 +591,10 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
             let v = self.vec[off];
             self.vec[off] = v | (T::max_value() << (self.len % bits_per_block::<T>()));
         }
-        self.vec.resize(blocks_required::<T>(new_len), if value {
-                                                           T::max_value()
-                                                       } else {
-                                                           T::zero()
-                                                       });
+        self.vec.resize(
+            blocks_required::<T>(new_len),
+            if value { T::max_value() } else { T::zero() },
+        );
         self.len = new_len;
         self.mask_last_block();
     }
@@ -716,11 +714,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// ```
     pub fn set_all(&mut self, value: bool) {
         for blk in self.vec.iter_mut() {
-            *blk = if value {
-                       T::max_value()
-                   } else {
-                       T::zero()
-                   };
+            *blk = if value { T::max_value() } else { T::zero() };
         }
         self.mask_last_block();
     }
@@ -763,7 +757,10 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// ```
     pub fn and(&mut self, other: &Vob<T>) -> bool {
         if self.len != other.len {
-            panic!("Cannot 'and' two Vobs of different length ({}  {})", self.len, other.len);
+            panic!(
+                "Cannot 'and' two Vobs of different length ({}  {})",
+                self.len, other.len
+            );
         }
         let mut chngd = false;
         for (self_blk, other_blk) in self.vec.iter_mut().zip(other.vec.iter()) {
@@ -798,7 +795,10 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// ```
     pub fn or(&mut self, other: &Vob<T>) -> bool {
         if self.len != other.len {
-            panic!("Cannot 'or' two Vobs of different length ({}  {})", self.len, other.len);
+            panic!(
+                "Cannot 'or' two Vobs of different length ({}  {})",
+                self.len, other.len
+            );
         }
         let mut chngd = false;
         for (self_blk, other_blk) in self.vec.iter_mut().zip(other.vec.iter()) {
@@ -833,7 +833,10 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// ```
     pub fn xor(&mut self, other: &Vob<T>) -> bool {
         if self.len != other.len {
-            panic!("Cannot 'xor' two Vobs of different length ({}  {})", self.len, other.len);
+            panic!(
+                "Cannot 'xor' two Vobs of different length ({}  {})",
+                self.len, other.len
+            );
         }
         let mut chngd = false;
         for (self_blk, other_blk) in self.vec.iter_mut().zip(other.vec.iter()) {
@@ -952,7 +955,7 @@ impl Default for Vob<usize> {
     fn default() -> Self {
         Vob {
             len: 0,
-            vec: Vec::new()
+            vec: Vec::new(),
         }
     }
 }
@@ -969,7 +972,7 @@ impl<T: Debug + One + PrimInt + Zero> Debug for Vob<T> {
 }
 
 impl<T: Debug + One + PrimInt + Zero> Extend<bool> for Vob<T> {
-    fn extend<I: IntoIterator<Item=bool>>(&mut self, iterable: I) {
+    fn extend<I: IntoIterator<Item = bool>>(&mut self, iterable: I) {
         let iterator = iterable.into_iter();
         let (min, _) = iterator.size_hint();
         self.reserve(min);
@@ -989,7 +992,7 @@ impl FromIterator<bool> for Vob<usize> {
     /// let v = Vob::from_iter(vec![true, false]);
     /// assert_eq!(v, Vob::from_iter(vec![true, false]));
     /// ```
-    fn from_iter<I: IntoIterator<Item=bool>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = bool>>(iter: I) -> Self {
         let mut v = Vob::new();
         v.extend(iter);
         v
@@ -1008,9 +1011,10 @@ impl<T: Debug + One + PrimInt + Zero> Index<usize> for Vob<T> {
         match self.get(index) {
             Some(true) => &TRUE,
             Some(false) => &FALSE,
-            None => panic!("index out of bounds: the len is {} but the index is {}",
-                           self.len,
-                           index)
+            None => panic!(
+                "index out of bounds: the len is {} but the index is {}",
+                self.len, index
+            ),
         }
     }
 }
@@ -1025,8 +1029,7 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for Iter<'a, T> {
     type Item = bool;
 
     fn next(&mut self) -> Option<bool> {
-        self.range.next()
-                  .map(|i| self.vob.get(i).unwrap())
+        self.range.next().map(|i| self.vob.get(i).unwrap())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1036,12 +1039,11 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for Iter<'a, T> {
 
 impl<'a, T: Debug + One + PrimInt + Zero> DoubleEndedIterator for Iter<'a, T> {
     fn next_back(&mut self) -> Option<bool> {
-        self.range.next_back()
-                  .map(|i| self.vob.get(i).unwrap())
+        self.range.next_back().map(|i| self.vob.get(i).unwrap())
     }
 }
 
-impl<'a, T: Debug + One + PrimInt + Zero> ExactSizeIterator for Iter<'a, T> { }
+impl<'a, T: Debug + One + PrimInt + Zero> ExactSizeIterator for Iter<'a, T> {}
 
 impl<'a, T: Debug + One + PrimInt + Zero> IntoIterator for &'a Vob<T> {
     type Item = bool;
@@ -1065,7 +1067,7 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for IterSetBits<'a, T> {
         debug_assert!(self.range.end <= self.vob.len);
         if let Some(mut i) = self.range.next() {
             // Bear in mind that i might not be aligned.
-            for b in block_offset::<T>(i) .. blocks_required::<T>(self.range.end) {
+            for b in block_offset::<T>(i)..blocks_required::<T>(self.range.end) {
                 let v = self.vob.vec[b];
                 if v != T::zero() {
                     // We have a block with a bit set. Find the next bit set after 'i %
@@ -1109,7 +1111,7 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for IterUnsetBits<'a, T> {
         debug_assert!(self.range.end <= self.vob.len);
         if let Some(mut i) = self.range.next() {
             // Bear in mind that i might not be aligned.
-            for b in block_offset::<T>(i) .. blocks_required::<T>(self.range.end) {
+            for b in block_offset::<T>(i)..blocks_required::<T>(self.range.end) {
                 let v = self.vob.vec[b];
                 if v != T::max_value() {
                     // We have a block with a bit unset. Find the next bit unset after 'i %
@@ -1154,7 +1156,7 @@ impl<T: Debug + One + PrimInt + Zero> PartialEq for Vob<T> {
 
 impl<T: Debug + One + PrimInt + Zero> Eq for Vob<T> {}
 
-impl<T :Debug + Hash + One + PrimInt + Zero> Hash for Vob<T> {
+impl<T: Debug + Hash + One + PrimInt + Zero> Hash for Vob<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         for blk in self.iter_storage() {
             blk.hash(state);
@@ -1198,10 +1200,10 @@ fn block_offset<T>(off: usize) -> usize {
 /// to store those bits.
 fn blocks_required<T>(num_bits: usize) -> usize {
     num_bits / bits_per_block::<T>() + if num_bits % bits_per_block::<T>() == 0 {
-                                           0
-                                       } else {
-                                           1
-                                       }
+        0
+    } else {
+        1
+    }
 }
 
 #[macro_export]
@@ -1293,8 +1295,10 @@ mod tests {
     #[test]
     fn test_capacity() {
         assert_eq!(Vob::new().capacity(), 0);
-        assert_eq!(Vob::with_capacity(size_of::<usize>() * 8 + 1).capacity(),
-                                      size_of::<usize>() * 8 * 2);
+        assert_eq!(
+            Vob::with_capacity(size_of::<usize>() * 8 + 1).capacity(),
+            size_of::<usize>() * 8 * 2
+        );
     }
 
     #[test]
@@ -1345,20 +1349,30 @@ mod tests {
 
         // Example adopted from BitVec
         let v = Vob::from_bytes(&[0b10100000, 0b00010010]);
-        assert_eq!(v, vob![true, false, true, false, false, false, false, false,
-                           false, false, false, true, false, false, true, false]);
+        assert_eq!(
+            v,
+            vob![
+                true, false, true, false, false, false, false, false, false, false, false, true,
+                false, false, true, false
+            ]
+        );
 
         // On a 64-bit machine, make sure we test that a complete word is dealt with correctly.
-        let v = Vob::from_bytes(&[0b10100000, 0b00010010, 0b00110101, 0b11001010,
-                                  0b00110001, 0b10010101, 0b01111100, 0b01010001]);
-        assert_eq!(v, vob![true, false, true, false, false, false, false, false,
-                           false, false, false, true, false, false, true, false,
-                           false, false, true, true, false, true, false, true,
-                           true, true, false, false, true, false, true, false,
-                           false, false, true, true, false, false, false, true,
-                           true, false, false, true, false, true, false, true,
-                           false, true, true, true, true, true, false, false,
-                           false, true, false, true, false, false, false, true]);
+        let v = Vob::from_bytes(&[
+            0b10100000, 0b00010010, 0b00110101, 0b11001010, 0b00110001, 0b10010101, 0b01111100,
+            0b01010001,
+        ]);
+        assert_eq!(
+            v,
+            vob![
+                true, false, true, false, false, false, false, false, false, false, false, true,
+                false, false, true, false, false, false, true, true, false, true, false, true,
+                true, true, false, false, true, false, true, false, false, false, true, true,
+                false, false, false, true, true, false, false, true, false, true, false, true,
+                false, true, true, true, true, true, false, false, false, true, false, true, false,
+                false, false, true
+            ]
+        );
     }
 
     #[test]
@@ -1456,17 +1470,32 @@ mod tests {
         v1.push(true);
         v1.resize(256, false);
         v1.push(true);
-        assert_eq!(v1.iter_set_bits(..).collect::<Vec<usize>>(), vec![1, 3, 127, 129, 130, 256]);
-        assert_eq!(v1.iter_set_bits(2..256).collect::<Vec<usize>>(), vec![3, 127, 129, 130]);
-        assert_eq!(v1.iter_set_bits(2..).collect::<Vec<usize>>(), vec![3, 127, 129, 130, 256]);
+        assert_eq!(
+            v1.iter_set_bits(..).collect::<Vec<usize>>(),
+            vec![1, 3, 127, 129, 130, 256]
+        );
+        assert_eq!(
+            v1.iter_set_bits(2..256).collect::<Vec<usize>>(),
+            vec![3, 127, 129, 130]
+        );
+        assert_eq!(
+            v1.iter_set_bits(2..).collect::<Vec<usize>>(),
+            vec![3, 127, 129, 130, 256]
+        );
         assert_eq!(v1.iter_set_bits(..3).collect::<Vec<usize>>(), vec![1]);
     }
 
     #[test]
     fn test_iter_unset_bits() {
         let mut v1 = vob![false, true, false, false];
-        assert_eq!(v1.iter_unset_bits(..).collect::<Vec<usize>>(), vec![0, 2, 3]);
-        assert_eq!(v1.iter_unset_bits(..10).collect::<Vec<usize>>(), vec![0, 2, 3]);
+        assert_eq!(
+            v1.iter_unset_bits(..).collect::<Vec<usize>>(),
+            vec![0, 2, 3]
+        );
+        assert_eq!(
+            v1.iter_unset_bits(..10).collect::<Vec<usize>>(),
+            vec![0, 2, 3]
+        );
         v1.resize(127, true);
         v1.push(false);
         v1.push(true);
@@ -1474,8 +1503,14 @@ mod tests {
         v1.push(false);
         v1.resize(256, true);
         v1.push(false);
-        assert_eq!(v1.iter_unset_bits(..).collect::<Vec<usize>>(), vec![0, 2, 3, 127, 129, 130, 256]);
-        assert_eq!(v1.iter_unset_bits(3..256).collect::<Vec<usize>>(), vec![3, 127, 129, 130]);
+        assert_eq!(
+            v1.iter_unset_bits(..).collect::<Vec<usize>>(),
+            vec![0, 2, 3, 127, 129, 130, 256]
+        );
+        assert_eq!(
+            v1.iter_unset_bits(3..256).collect::<Vec<usize>>(),
+            vec![3, 127, 129, 130]
+        );
     }
 
     #[test]

--- a/src/range.rs
+++ b/src/range.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ops::{RangeFull, Range, RangeTo, RangeFrom};
 pub use std::collections::Bound::{self, Excluded, Included, Unbounded};
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 
 pub trait RangeBounds<T: ?Sized> {
     fn start_bound(&self) -> Bound<&T>;


### PR DESCRIPTION
Also formats the code.

Only run `cargo fmt` on nightly, as there may be differences between versions.