### PR TITLE
Make new_with_storage_type create Vec with correct capacity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     pub fn new_with_storage_type(capacity: usize) -> Vob<T> {
         Vob {
             len: 0,
-            vec: Vec::with_capacity(capacity),
+            vec: Vec::with_capacity(blocks_required::<T>(capacity)),
         }
     }
 


### PR DESCRIPTION
It is currently creating a greatly oversized `Vec`, as it is
directly taking the given capacity (supposedly bits) but reserving
for that many Ts.