### PR TITLE
Don't mask in xor, it's not necessary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,7 +810,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
                 chngd = true;
             }
         }
-        // We don't need to mask the last block as those bits can't be set by "|" by definition.
+        // We don't need to mask the last block per our assumptions
         chngd
     }
 
@@ -848,7 +848,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
                 chngd = true;
             }
         }
-        self.mask_last_block();
+        // We don't need to mask the last block per our assumptions
         chngd
     }
 


### PR DESCRIPTION
0 ^ 0 = 0

Also correct the comment in `or`, which is based on an incorrect assumption.