### PR TITLE
Bump version to 1.3.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# vob 1.3.1 (2018-06-20)
+
+* Don't overallocate memory in `new_with_storage_type`.
+
 # vob 1.3.0 (2018-06-11)
 
 * Add `extend_from_vob` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vob"
 description = "Vector of Bits with Vec-like API and usize backing storage"
 repository = "https://github.com/softdevteam/vob/"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about


### PR DESCRIPTION
@thomwiggers I've sent a collaborator request to you for this repo, if you're willing. That way I can assign PRs like this one to you so that you can review and, if they're good enough quality, eventually merge (after reviewing and squashing etc).

This PR bumps Vob to 1.3.1 to include the `new_with_storage_type` fix which is harmless, but useful to anyone who's using Vob 1.3.0.