### PR TITLE
Speed up binary operations by eliminating branches

### DIFF
--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -2,8 +2,10 @@
 
 #[macro_use]
 extern crate vob;
+extern crate rand;
 extern crate test;
 
+use rand::Rng;
 use test::Bencher;
 use vob::*;
 
@@ -58,5 +60,44 @@ fn split_off(b: &mut Bencher) {
     b.iter(|| {
         let mut a = source.clone();
         a.split_off(N / 2)
+    });
+}
+
+#[bench]
+fn xor(bench: &mut Bencher) {
+    let mut a = Vob::with_capacity(N);
+    let mut rng = rand::thread_rng();
+    a.extend((0..N).map(|_| rng.gen::<bool>()));
+    let mut b = Vob::with_capacity(N);
+    b.extend((0..N).map(|_| rng.gen::<bool>()));
+
+    bench.iter(|| {
+        a.xor(&b);
+    });
+}
+
+#[bench]
+fn or(bench: &mut Bencher) {
+    let mut a = Vob::with_capacity(N);
+    let mut rng = rand::thread_rng();
+    a.extend((0..N).map(|_| rng.gen::<bool>()));
+    let mut b = Vob::with_capacity(N);
+    b.extend((0..N).map(|_| rng.gen::<bool>()));
+
+    bench.iter(|| {
+        a.or(&b);
+    });
+}
+
+#[bench]
+fn and(bench: &mut Bencher) {
+    let mut a = Vob::with_capacity(N);
+    let mut rng = rand::thread_rng();
+    a.extend((0..N).map(|_| rng.gen::<bool>()));
+    let mut b = Vob::with_capacity(N);
+    b.extend((0..N).map(|_| rng.gen::<bool>()));
+
+    bench.iter(|| {
+        a.and(&b);
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -752,7 +752,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// fn main() {
     ///     let mut v1 = vob![true, false, false];
     ///     let v2 = vob![true, true, false];
-    ///     v1.and(&v2);
+    ///     assert_eq!(v1.and(&v2), false);
     ///     assert_eq!(v1, vob![true, false, false]);
     /// }
     /// ```
@@ -767,10 +767,8 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         for (self_blk, other_blk) in self.vec.iter_mut().zip(other.vec.iter()) {
             let old_v = *self_blk;
             let new_v = old_v & *other_blk;
-            if old_v != new_v {
-                *self_blk = new_v;
-                chngd = true;
-            }
+            *self_blk = new_v;
+            chngd = chngd | (old_v != new_v);
         }
         // We don't need to mask the last block as those bits can't be set by "&" by definition.
         chngd
@@ -790,7 +788,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// fn main() {
     ///     let mut v1 = vob![true, false, false];
     ///     let v2 = vob![false, true, false];
-    ///     v1.or(&v2);
+    ///     assert_eq!(v1.or(&v2), true);
     ///     assert_eq!(v1, vob![true, true, false]);
     /// }
     /// ```
@@ -805,10 +803,8 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         for (self_blk, other_blk) in self.vec.iter_mut().zip(other.vec.iter()) {
             let old_v = *self_blk;
             let new_v = old_v | *other_blk;
-            if old_v != new_v {
-                *self_blk = new_v;
-                chngd = true;
-            }
+            *self_blk = new_v;
+            chngd = chngd | (old_v != new_v);
         }
         // We don't need to mask the last block per our assumptions
         chngd
@@ -828,7 +824,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     /// fn main() {
     ///     let mut v1 = vob![true, false, true];
     ///     let v2 = vob![false, true, true];
-    ///     v1.xor(&v2);
+    ///     assert_eq!(v1.xor(&v2), true);
     ///     assert_eq!(v1, vob![true, true, false]);
     /// }
     /// ```
@@ -843,10 +839,8 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         for (self_blk, other_blk) in self.vec.iter_mut().zip(other.vec.iter()) {
             let old_v = *self_blk;
             let new_v = old_v ^ *other_blk;
-            if old_v != new_v {
-                *self_blk = new_v;
-                chngd = true;
-            }
+            *self_blk = new_v;
+            chngd = chngd | (old_v != new_v);
         }
         // We don't need to mask the last block per our assumptions
         chngd


### PR DESCRIPTION
I've benchmarked the binary operations and came to ~1250 ns per iteration.
Eliminating the branches, it's now down to ~750 ns.