### PR TITLE
Faster iteration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ env:
   - FEATURES='unsafe_internals'
 
 before_script:
-  - rustup component add rustfmt-preview
+  - "[ \"$TRAVIS_RUST_VERSION\" == 'nightly' ] || rustup component add rustfmt-preview"
 
 script:
-  - cargo fmt --all -- --check
   - cargo build --tests --features "$FEATURES"
   - cargo test --features "$FEATURES"
-  - "[ \"$TRAVIS_RUST_VERSION\" != 'nightly' ] ||  cargo bench --features \"$FEATURES\""
-  - "[ \"$TRAVIS_RUST_VERSION\" != 'nightly' ] ||  cargo fmt -- --check"
+  - "[ \"$TRAVIS_RUST_VERSION\" != 'nightly' ] || cargo bench --features \"$FEATURES\""
+  - "[ \"$TRAVIS_RUST_VERSION\" == 'nightly' ] || cargo fmt --all -- --check"
 
 cache: cargo

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# vob 2.0.1 (2018-12-11)
+
+* Substantially speed up `iter_\[set|unset\]_bits` for the common case where all
+  bits are set/unset (respectively). This leads to a 3x improvement in such
+  cases, with no measurable slowdown in the general case.
+
 # vob 2.0.0 (2018-10-10)
 
 * Change `set` so that if passed an out of bounds index it panics (previously it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vob"
 description = "Vector of Bits with Vec-like API and usize backing storage"
 repository = "https://github.com/softdevteam/vob/"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -118,3 +118,15 @@ fn iter_set_bits(bench: &mut Bencher) {
     a.extend((0..N).map(|_| rng.gen::<bool>()));
     bench.iter(|| a.iter_set_bits(..).count());
 }
+
+#[bench]
+fn iter_all_set_bits(bench: &mut Bencher) {
+    let a = Vob::from_elem(N, true);
+    bench.iter(|| a.iter_set_bits(..).count());
+}
+
+#[bench]
+fn iter_all_unset_bits(bench: &mut Bencher) {
+    let a = Vob::from_elem(N, true);
+    bench.iter(|| a.iter_unset_bits(..).count());
+}

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -120,6 +120,14 @@ fn iter_set_bits(bench: &mut Bencher) {
 }
 
 #[bench]
+fn iter_set_bits_u8(bench: &mut Bencher) {
+    let mut a = Vob::<u8>::new_with_storage_type(N);
+    let mut rng = rand::thread_rng();
+    a.extend((0..N).map(|_| rng.gen::<bool>()));
+    bench.iter(|| a.iter_set_bits(..).count());
+}
+
+#[bench]
 fn iter_all_set_bits(bench: &mut Bencher) {
     let a = Vob::from_elem(N, true);
     bench.iter(|| a.iter_set_bits(..).count());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1245,11 +1245,12 @@ fn block_offset<T>(off: usize) -> usize {
 /// Takes as input a number of bits requiring storage; returns an aligned number of blocks needed
 /// to store those bits.
 fn blocks_required<T>(num_bits: usize) -> usize {
-    num_bits / bits_per_block::<T>() + if num_bits % bits_per_block::<T>() == 0 {
-        0
-    } else {
-        1
-    }
+    num_bits / bits_per_block::<T>()
+        + if num_bits % bits_per_block::<T>() == 0 {
+            0
+        } else {
+            1
+        }
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1080,9 +1080,19 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for IterSetBits<'a, T> {
     fn next(&mut self) -> Option<usize> {
         debug_assert!(self.range.end <= self.vob.len);
         if let Some(mut i) = self.range.next() {
-            // Bear in mind that i might not be aligned.
-            for b in block_offset::<T>(i)..blocks_required::<T>(self.range.end) {
-                let v = self.vob.vec[b];
+            // This is a long, but fast, way of finding out what the next set bit is. The basic
+            // idea is that we try and hit the fastest possible case (a block with all bits set)
+            // with minimal operations first, falling back to the general case only if we have to.
+            let mut b = block_offset::<T>(i);
+            let mut v = self.vob.vec[b];
+            if v == T::max_value() {
+                return Some(i);
+            }
+            // At this point we've got a block which might or might not have some bits set. We now
+            // fall back to the general case.
+            loop {
+                // If this block doesn't have any bits set at all, we can zoom straight on to the
+                // next block.
                 if v != T::zero() {
                     // We have a block with a bit set. Find the next bit set after 'i %
                     // bits_per_block()', bearing in mind that it may have been the last bit set
@@ -1100,10 +1110,16 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for IterSetBits<'a, T> {
                         }
                     }
                 }
+                b += 1;
+                if b == blocks_required::<T>(self.range.end) {
+                    // We've exhausted the iterator.
+                    self.range.start = self.range.end;
+                    break;
+                }
+                v = self.vob.vec[b];
                 i = b * bits_per_block::<T>();
             }
         }
-        self.range.start = self.range.end;
         None
     }
 
@@ -1124,9 +1140,19 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for IterUnsetBits<'a, T> {
     fn next(&mut self) -> Option<usize> {
         debug_assert!(self.range.end <= self.vob.len);
         if let Some(mut i) = self.range.next() {
-            // Bear in mind that i might not be aligned.
-            for b in block_offset::<T>(i)..blocks_required::<T>(self.range.end) {
-                let v = self.vob.vec[b];
+            // This is a long, but fast, way of finding out what the next unset bit is. The basic
+            // idea is that we try and hit the fastest possible case (a block with all bits unset)
+            // with minimal operations first, falling back to the general case only if we have to.
+            let mut b = block_offset::<T>(i);
+            let mut v = self.vob.vec[b];
+            if v == T::zero() {
+                return Some(i);
+            }
+            // At this point we've got a block which might or might not have some bits unset. We
+            // now fall back to the general case.
+            loop {
+                // If this block doesn't have any unset bits at all, we can zoom straight on to the
+                // next block.
                 if v != T::max_value() {
                     // We have a block with a bit unset. Find the next bit unset after 'i %
                     // bits_per_block()', bearing in mind that it may have been the last bit unset
@@ -1145,10 +1171,16 @@ impl<'a, T: Debug + One + PrimInt + Zero> Iterator for IterUnsetBits<'a, T> {
                         return Some(bs);
                     }
                 }
+                b += 1;
+                if b == blocks_required::<T>(self.range.end) {
+                    // We've exhausted the iterator.
+                    self.range.start = self.range.end;
+                    break;
+                }
+                v = self.vob.vec[b];
                 i = b * bits_per_block::<T>();
             }
         }
-        self.range.start = self.range.end;
         None
     }
 


### PR DESCRIPTION
The basic idea here is to deal with a common case which is that we have blocks with all bits set/unset: we can deal with these without doing anything more than a load and a compare. Rethinking the loop allows us to make this case as fast as possible; if we don't hit it, we fall back to the general case. This does make the code a bit harder to follow, but it handles the edge cases well: iterating over a Vob with iter_set_bits and all bits set is a bit over 3x faster with this change, with the general case statistically unchanged. Iterating over a Vob with iter_set_bits and all bits unset is about 40% faster, though this means it changes from "very fast" to "very very fast" (i.e. I doubt anyone will notice, given the absolute speed was high before).

Benchmarks from my machine before:

```
  test and                    ... bench:         429 ns/iter (+/- 9)
  test empty                  ... bench:         131 ns/iter (+/- 1)
  test extend                 ... bench:     338,070 ns/iter (+/- 3,002)
  test extend_vob_aligned     ... bench:       1,981 ns/iter (+/- 34)
  test extend_vob_not_aligned ... bench:       3,563 ns/iter (+/- 65)
  test from_bytes             ... bench:       1,900 ns/iter (+/- 54)
  test iter_all_set_bits      ... bench:     303,086 ns/iter (+/- 10,734)
  test iter_all_unset_bits    ... bench:       1,423 ns/iter (+/- 43)
  test iter_set_bits          ... bench:     159,042 ns/iter (+/- 3,711)
  test or                     ... bench:         429 ns/iter (+/- 4)
  test split_off              ... bench:       2,238 ns/iter (+/- 25)
  test xor                    ... bench:         429 ns/iter (+/- 5)
```

and after:

```
  test and                    ... bench:         429 ns/iter (+/- 4)
  test empty                  ... bench:         123 ns/iter (+/- 0)
  test extend                 ... bench:     338,047 ns/iter (+/- 3,640)
  test extend_vob_aligned     ... bench:       1,984 ns/iter (+/- 26)
  test extend_vob_not_aligned ... bench:       3,532 ns/iter (+/- 80)
  test from_bytes             ... bench:       1,900 ns/iter (+/- 36)
  test iter_all_set_bits      ... bench:      90,804 ns/iter (+/- 1,389)
  test iter_all_unset_bits    ... bench:         895 ns/iter (+/- 9)
  test iter_set_bits          ... bench:     161,703 ns/iter (+/- 5,251)
  test or                     ... bench:         429 ns/iter (+/- 5)
  test split_off              ... bench:       2,288 ns/iter (+/- 27)
  test xor                    ... bench:         428 ns/iter (+/- 21)
```

Notice that there is some variation in the iter_all_set_bits benchmark: sometimes it's much faster again (~65,000 ns/iter). I don't know why.

These numbers are, unsurprisingly, virtually identical for iter_unset_bits.

Since (assuming I haven't made any mistakes!), this is a simple change, this also seems like a good candidate for a new release.