### PR TITLE
Better mixed iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ num-traits = "0.2.1"
 serde = { version="1.0", features=["derive"], optional=true }
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.6"
+rand_pcg = "0.1"
 
 [features]
 unsafe_internals = []

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -1,15 +1,17 @@
 #![feature(test)]
 
-#[macro_use]
-extern crate vob;
 extern crate rand;
+extern crate rand_pcg;
 extern crate test;
+extern crate vob;
 
-use rand::Rng;
+use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64Mcg;
 use test::Bencher;
 use vob::*;
 
 const N: usize = 100000;
+const RNG_SEED: u64 = 15770844968783748344;
 
 #[bench]
 fn empty(bench: &mut Bencher) {
@@ -66,7 +68,7 @@ fn split_off(bench: &mut Bencher) {
 #[bench]
 fn xor(bench: &mut Bencher) {
     let mut v1 = Vob::with_capacity(N);
-    let mut rng = rand::thread_rng();
+    let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     v1.extend((0..N).map(|_| rng.gen::<bool>()));
     let mut v2 = Vob::with_capacity(N);
     v2.extend((0..N).map(|_| rng.gen::<bool>()));
@@ -79,7 +81,7 @@ fn xor(bench: &mut Bencher) {
 #[bench]
 fn or(bench: &mut Bencher) {
     let mut v1 = Vob::with_capacity(N);
-    let mut rng = rand::thread_rng();
+    let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     v1.extend((0..N).map(|_| rng.gen::<bool>()));
     let mut v2 = Vob::with_capacity(N);
     v2.extend((0..N).map(|_| rng.gen::<bool>()));
@@ -92,7 +94,7 @@ fn or(bench: &mut Bencher) {
 #[bench]
 fn and(bench: &mut Bencher) {
     let mut v1 = Vob::with_capacity(N);
-    let mut rng = rand::thread_rng();
+    let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     v1.extend((0..N).map(|_| rng.gen::<bool>()));
     let mut v2 = Vob::with_capacity(N);
     v2.extend((0..N).map(|_| rng.gen::<bool>()));
@@ -114,7 +116,7 @@ fn from_bytes(bench: &mut Bencher) {
 #[bench]
 fn iter_set_bits(bench: &mut Bencher) {
     let mut a = Vob::with_capacity(N);
-    let mut rng = rand::thread_rng();
+    let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     a.extend((0..N).map(|_| rng.gen::<bool>()));
     bench.iter(|| a.iter_set_bits(..).count());
 }
@@ -122,7 +124,7 @@ fn iter_set_bits(bench: &mut Bencher) {
 #[bench]
 fn iter_set_bits_u8(bench: &mut Bencher) {
     let mut a = Vob::<u8>::new_with_storage_type(N);
-    let mut rng = rand::thread_rng();
+    let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     a.extend((0..N).map(|_| rng.gen::<bool>()));
     bench.iter(|| a.iter_set_bits(..).count());
 }


### PR DESCRIPTION
Previously, there was a definite performance penalty when iterating over data with random-ish sequences of set/unset bits. This commit makes that case better by simplifying the relevant code paths.

For reasons that I don't understand, the "all bits set" case gets a bit worse, even though the source-level code path is unchanged. I'll assume the optimising compiler did something clever, which isn't actually very clever.

On my machine, here are the benchmarks before:

```
  running 13 tests
  test and                    ... bench:         429 ns/iter (+/- 1)
  test empty                  ... bench:         136 ns/iter (+/- 1)
  test extend                 ... bench:     338,258 ns/iter (+/- 2,247)
  test extend_vob_aligned     ... bench:       1,997 ns/iter (+/- 18)
  test extend_vob_not_aligned ... bench:       3,565 ns/iter (+/- 50)
  test from_bytes             ... bench:       1,900 ns/iter (+/- 7)
  test iter_all_set_bits      ... bench:      62,489 ns/iter (+/- 211)
  test iter_all_unset_bits    ... bench:         893 ns/iter (+/- 3)
  test iter_set_bits          ... bench:     161,624 ns/iter (+/- 984)
  test iter_set_bits_u8       ... bench:     211,300 ns/iter (+/- 834)
  test or                     ... bench:         428 ns/iter (+/- 2)
  test split_off              ... bench:       2,234 ns/iter (+/- 10)
  test xor                    ... bench:         428 ns/iter (+/- 2)
```

and after:

```
  test and                    ... bench:         429 ns/iter (+/- 2)
  test empty                  ... bench:         129 ns/iter (+/- 1)
  test extend                 ... bench:     337,833 ns/iter (+/- 10,499)
  test extend_vob_aligned     ... bench:       1,985 ns/iter (+/- 10)
  test extend_vob_not_aligned ... bench:       3,529 ns/iter (+/- 11)
  test from_bytes             ... bench:       1,893 ns/iter (+/- 8)
  test iter_all_set_bits      ... bench:      68,122 ns/iter (+/- 596)
  test iter_all_unset_bits    ... bench:         725 ns/iter (+/- 7)
  test iter_set_bits          ... bench:     150,511 ns/iter (+/- 346)
  test iter_set_bits_u8       ... bench:     196,363 ns/iter (+/- 677)
  test or                     ... bench:         428 ns/iter (+/- 3)
  test split_off              ... bench:       2,250 ns/iter (+/- 12)
  test xor                    ... bench:         429 ns/iter (+/- 7)
```