### PR TITLE
added to_bytes() function and tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,6 +481,43 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         }
     }
 
+    ///Returns contents of Vob as Vec of bytes.
+    ///
+    ///For a Vob of length n, the first bit will be the 0th element,
+    ///the last bit would be the (n-1)th element.
+    ///
+    /// # Examples
+    /// ```
+    ///use vob::Vob;
+    ///let mut x = Vob::from_elem(5, false);
+    ///x.set(2, true);
+    ///x.set(4, true);
+    ///assert_eq!(x.to_bytes(), [0b00101000]);
+    ///```
+    pub fn to_bytes(&self) -> Vec<u8> {
+        fn bit<T: Debug + One + PrimInt + Zero>(vob: &Vob<T>, byte: usize, bit: usize) -> u8 {
+            let offset = byte * 8 + bit;
+            if offset >= vob.len {
+                0
+            } else {
+                (vob[offset] as u8) << (7 - bit)
+            }
+        }
+
+        let len = self.len / 8 +
+                  if self.len % 8 == 0 { 0 } else { 1 };
+        (0..len).map(|i|
+            bit(self, i, 0) |
+            bit(self, i, 1) |
+            bit(self, i, 2) |
+            bit(self, i, 3) |
+            bit(self, i, 4) |
+            bit(self, i, 5) |
+            bit(self, i, 6) |
+            bit(self, i, 7)
+        ).collect()
+    }
+
     /// Returns an iterator over the slice.
     ///
     /// # Examples
@@ -1660,4 +1697,20 @@ mod tests {
         v.push(true);
         assert_eq!(v.vec.len(), 1);
     }
+
+    #[test]
+    fn to_bytes() {
+        let mut x = Vob::from_elem(3, true);
+        x.set(1, false);
+        assert_eq!(x.to_bytes(), [0b10100000]);
+    }
+
+    #[test]
+    fn to_bytes_larger(){
+        let mut x = Vob::from_elem(9, false);
+        x.set(2, true);
+        x.set(8, true);
+        assert_eq!(x.to_bytes(), [0b00100000, 0b10000000]);
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1717,7 +1717,7 @@ mod tests {
         assert_eq!(x.to_bytes(), [255]);
     }
     #[test]
-    fn to_bytes_mutliple_words() {
+    fn to_bytes_multiple_words() {
         let x = Vob::from_elem(72, true);
         assert_eq!(x.to_bytes(), [255, 255, 255, 255, 255, 255, 255, 255, 255]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1706,6 +1706,12 @@ mod tests {
     }
 
     #[test]
+    fn to_bytes_empty() {
+        let x = Vob::new();
+        assert_eq!(x.to_bytes(), []);
+    }
+
+    #[test]
     fn to_bytes_single_byte() {
         let x = Vob::from_elem(8, true);
         assert_eq!(x.to_bytes(), [255]);
@@ -1714,12 +1720,6 @@ mod tests {
     fn to_bytes_mutliple_words() {
         let x = Vob::from_elem(72, true);
         assert_eq!(x.to_bytes(), [255, 255, 255, 255, 255, 255, 255, 255, 255]);
-    }
-
-    #[test]
-    fn to_bytes_empty() {
-        let x = Vob::new();
-        assert_eq!(x.to_bytes(), []);
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,7 +492,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut v: Vec<u8> = Vec::new();
         for j in 0..self.vec.len() {
-            let mut current_block = self.vec[j];
+            let current_block = self.vec[j];
             let bytes_per_block = bytes_per_block::<T>();
             for i in (0..bytes_per_block).rev() {
                 let x = current_block
@@ -502,7 +502,20 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
                     .unwrap();
                 let y: u8 = num_traits::cast::cast(x >> 8 * (bytes_per_block - 1 - i)).unwrap();
                 if y != 0 {
-                    v.push(y.reverse_bits());
+                    #[cfg(not(reverse_bits))]
+                    {
+                        {
+                            let mut rb: u8 = 0; // the byte b with its bits in reverse order
+                            for k in 0..8 {
+                                rb |= ((y >> k) & 1) << (8 - k - 1);
+                            }
+                            v.push(rb);
+                        }
+                    }
+                    #[cfg(reverse_bits)]
+                    {
+                        v.push(y.reverse_bits());
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,19 +481,19 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         }
     }
 
-    ///Returns contents of Vob as Vec of bytes.
+    /// Returns contents of Vob as Vec of bytes.
     ///
-    ///For a Vob of length n, the first bit will be the 0th element,
-    ///the last bit would be the (n-1)th element.
+    /// For a Vob of length n, the first bit will be the 0th element,
+    /// the last bit would be the (n-1)th element.
     ///
     /// # Examples
     /// ```
-    ///use vob::Vob;
-    ///let mut x = Vob::from_elem(5, false);
-    ///x.set(2, true);
-    ///x.set(4, true);
-    ///assert_eq!(x.to_bytes(), [0b00101000]);
-    ///```
+    /// use vob::Vob;
+    /// let mut x = Vob::from_elem(5, false);
+    /// x.set(2, true);
+    /// x.set(4, true);
+    /// assert_eq!(x.to_bytes(), [0b00101000]);
+    /// ```
     pub fn to_bytes(&self) -> Vec<u8> {
         fn bit<T: Debug + One + PrimInt + Zero>(vob: &Vob<T>, byte: usize, bit: usize) -> u8 {
             let offset = byte * 8 + bit;
@@ -504,18 +504,20 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
             }
         }
 
-        let len = self.len / 8 +
-                  if self.len % 8 == 0 { 0 } else { 1 };
-        (0..len).map(|i|
-            bit(self, i, 0) |
-            bit(self, i, 1) |
-            bit(self, i, 2) |
-            bit(self, i, 3) |
-            bit(self, i, 4) |
-            bit(self, i, 5) |
-            bit(self, i, 6) |
-            bit(self, i, 7)
-        ).collect()
+        let len = self.len / 8 + if self.len % 8 == 0 { 0 } else { 1 };
+        let x = (0..len)
+            .map(|i| {
+                bit(self, i, 0)
+                    | bit(self, i, 1)
+                    | bit(self, i, 2)
+                    | bit(self, i, 3)
+                    | bit(self, i, 4)
+                    | bit(self, i, 5)
+                    | bit(self, i, 6)
+                    | bit(self, i, 7)
+            })
+            .collect();
+        return x;
     }
 
     /// Returns an iterator over the slice.
@@ -1704,9 +1706,20 @@ mod tests {
         x.set(1, false);
         assert_eq!(x.to_bytes(), [0b10100000]);
     }
+    #[test]
+    fn to_bytes_empty() {
+        let x = Vob::new();
+        assert_eq!(x.to_bytes(), []);
+    }
+    #[test]
+    fn to_bytes_8() {
+        let mut x = Vob::from_elem(8, true);
+        x.set(1, false);
+        assert_eq!(x.to_bytes(), [0b10111111]);
+    }
 
     #[test]
-    fn to_bytes_larger(){
+    fn to_bytes_larger() {
         let mut x = Vob::from_elem(9, false);
         x.set(2, true);
         x.set(8, true);


### PR DESCRIPTION
I've added a to_bytes() function which returns the contents of a Vob in byte form.
For example:
```let mut x = Vob::from_elem(3, true);```
calling ```to_bytes()``` on ```x``` would return ```[0b10100000]``` 