### PR TITLE
Move to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 # UPL-1.0.
 license = "Apache-2.0 OR MIT"
 categories = ["data-structures"]
+edition = "2018"
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -1,9 +1,6 @@
 #![feature(test)]
 
-extern crate rand;
-extern crate rand_pcg;
 extern crate test;
-extern crate vob;
 
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64Mcg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,6 @@
 //!
 //! The main documentation for this crate can be found in the [`Vob`](struct.Vob.html) struct.
 
-extern crate num_traits;
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-#[cfg(test)]
-extern crate rand;
-
 use std::{
     cmp::{min, PartialEq},
     fmt::{self, Debug},
@@ -31,6 +24,8 @@ use std::{
 };
 
 use num_traits::{One, PrimInt, Zero};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 // Whilst we wait for https://github.com/rust-lang/rust/issues/30877 to become stable, we can't use
 // RangeBounds and friends. We therefore have to implement a subset of the expected functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,7 +783,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
             let old_v = *self_blk;
             let new_v = old_v & *other_blk;
             *self_blk = new_v;
-            chngd = chngd | (old_v != new_v);
+            chngd |= old_v != new_v;
         }
         // We don't need to mask the last block as those bits can't be set by "&" by definition.
         chngd
@@ -819,7 +819,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
             let old_v = *self_blk;
             let new_v = old_v | *other_blk;
             *self_blk = new_v;
-            chngd = chngd | (old_v != new_v);
+            chngd |= old_v != new_v;
         }
         // We don't need to mask the last block per our assumptions
         chngd
@@ -855,7 +855,7 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
             let old_v = *self_blk;
             let new_v = old_v ^ *other_blk;
             *self_blk = new_v;
-            chngd = chngd | (old_v != new_v);
+            chngd |= old_v != new_v;
         }
         // We don't need to mask the last block per our assumptions
         chngd


### PR DESCRIPTION
This does reduce backwards compatibility (one can't use old versions of rustc), but I think that's a minor worry at best.