### PR TITLE
Remove pointless type annotation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1557,7 +1557,7 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        let v1 = Vob::<usize>::from_iter(vec![true, false]);
+        let v1 = Vob::from_iter(vec![true, false]);
         let v2 = Vob::from_iter(vec![true, false]);
         assert_eq!(v1, v2);
         let v3 = Vob::from_iter(vec![true, true]);


### PR DESCRIPTION
I'm not sure how this was left in, as any other type in this position would be invalid!