### PR TITLE
Fix rand crate version specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2.1"
 serde = { version="1.0", features=["derive"], optional=true }
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.6.0"
 rand_pcg = "0.1"
 
 [features]


### PR DESCRIPTION
Because it was specified as `0.6`, it would try to use a not backwards-compatible version.