### PR TITLE
Use rustfmt's defaults.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-indent_style="Block"
-imports_indent="Block"
-use_try_shorthand=true
-use_field_init_shorthand=true
-merge_imports=true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,8 @@ impl<T: Debug + PrimInt + One + Zero> Vob<T> {
         }
 
         // Compute new length for self.
-        let new_len = self.len
+        let new_len = self
+            .len
             //  the subtraction won't overflow because of the bounds assumption above.
             .checked_add(other.len() - block_offset * bits_per_block::<T>())
             .expect("Overflow detected");


### PR DESCRIPTION
Clinging on to custom settings probably doesn't make sense any more.

Will almost certainly need https://github.com/softdevteam/vob/pull/50 merged first.