### PR TITLE
Prepare a 3.0.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,16 +16,19 @@
 * Clearly document the invariants users must maintain when using the `unsafe`
   parts of the API.
 
+
 # vob 2.0.5 (2020-09-02)
 
 * Use rustfmt stable.
 * Remove unnecessary ``fn main`` wrappers in doctest examples.
 * Clean up two remaining ``#[macro use] extern crate vob;`` lines from examples.
 
+
 # vob 2.0.4 (2019-11-21)
 
 * License as dual Apache-2.0/MIT (instead of a more complex, and little
   understood, triple license of Apache-2.0/MIT/UPL-1.0).
+
 
 # vob 2.0.3 (2019-08-21)
 
@@ -34,10 +37,12 @@
 * On rustc-1.37 and later, automatically use `reverse_bits` (this automatically
   includes the current nightly version of rustc).
 
+
 # vob 2.0.2 (2018-12-18)
 
 * Further speed up `iter_\[set|unset\]_bits` for cases where set/unset bits are
   fairly randomly distributed (by approximately 10%).
+
 
 # vob 2.0.1 (2018-12-11)
 
@@ -45,11 +50,13 @@
   bits are set/unset (respectively). This leads to a 3x improvement in such
   cases, with no measurable slowdown in the general case.
 
+
 # vob 2.0.0 (2018-10-10)
 
 * Change `set` so that if passed an out of bounds index it panics (previously it
   returned None, but since one doesn't generally check the return value of
   `set`, this led to errors being overlooked).
+
 
 # vob 1.3.2 (2018-06-30)
 
@@ -57,9 +64,11 @@
 * Add `fast_reverse` feature: on nightly, we automatically try to use the
   `fast_reverse` function to improve performance.
 
+
 # vob 1.3.1 (2018-06-20)
 
 * Don't overallocate memory in `new_with_storage_type`.
+
 
 # vob 1.3.0 (2018-06-11)
 
@@ -69,13 +78,16 @@
 * Various performance improvements.
 * Use `rustfmt`.
 
+
 # vob 1.2.0 (2018-05-08)
 
 * Add `from_bytes` function.
 
+
 # vob 1.1.0 (2018-03-29)
 
 * Add `serde` feature to enable [Serde](https://serde.rs/) support.
+
 
 # vob 1.0.0 (2018-03-14)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+# vob 3.0.0 (2021-09-20)
+
+## Breaking changes
+
+* `Vob::from_elem(value: bool, len: usize)` now takes the value first and the
+  number of repetitions of that value second to mirror the most common way this
+  function is defined elsewhere.
+
+* The `vob!` macro's repetition form now mirrors `vec!`, so `vob![val; len]` is
+  equivalent to `Vec::from_elem(val, len)`.
+
+
 # vob 2.0.6 (2021-01-25)
 
 * Add `get_storage` to the `unsafe_internals` portion of the API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vob"
 description = "Vector of Bits with Vec-like API and usize backing storage"
 repository = "https://github.com/softdevteam/vob/"
-version = "2.0.6"
+version = "3.0.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1237,8 +1237,8 @@ macro_rules! vob {
     // (macro_at_most_once_rep) stabilises
     ($($rest:expr),+,) => ( vob!($($rest),+) );
     (@count $($rest:expr),*) => (<[()]>::len(&[$(vob!(@single $rest)),*]));
-    ($n:expr; $elem:expr) => (
-        $crate::Vob::from_elem($n, $elem)
+    ($val:expr; $len:expr) => (
+        $crate::Vob::from_elem($val, $len)
     );
     () => (Vob::new());
     ($($x:expr),*) => ({


### PR DESCRIPTION
Note there is one code change here (https://github.com/softdevteam/vob/commit/8e8a7c1f44bb08a902ace5784886e65c01c25f79) though it *should* be a "simple" alpha-renaming.