### PR TITLE
Move to Criterion for benchmarking.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -14,6 +14,7 @@ cargo test
 cargo test --features "unsafe_internals"
 cargo test --release
 cargo test --release --features "unsafe_internals"
+cargo bench
 
 cargo fmt --all -- --check
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,13 @@ num-traits = "0.2.14"
 serde = { version="1.0", features=["derive"], optional=true }
 
 [dev-dependencies]
+criterion = "0.5"
 rand = "0.8"
 rand_pcg = "0.3"
+
+[[bench]]
+name = "vob"
+harness = false
 
 [features]
 unsafe_internals = []

--- a/benches/vob.rs
+++ b/benches/vob.rs
@@ -1,139 +1,160 @@
-#![feature(test)]
-
-extern crate test;
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64Mcg;
-use test::Bencher;
 use vob::*;
 
 const N: usize = 100000;
 const RNG_SEED: u64 = 15770844968783748344;
 
-#[bench]
-fn empty(bench: &mut Bencher) {
-    bench.iter(|| Vob::with_capacity(N));
+fn empty(c: &mut Criterion) {
+    c.bench_function("empty", |b| b.iter(|| Vob::with_capacity(N)));
 }
 
-#[bench]
-fn extend(bench: &mut Bencher) {
+fn extend(c: &mut Criterion) {
     // first initialise the source vector to drain
     let mut v1 = Vob::with_capacity(N);
     v1.extend((0..N).map(|i| i % 2 == 0));
 
-    bench.iter(|| {
-        let mut v2 = Vob::with_capacity(N);
-        v2.extend(v1.iter())
+    c.bench_function("extend", |b| {
+        b.iter(|| {
+            let mut v2 = Vob::with_capacity(N);
+            v2.extend(v1.iter())
+        })
     });
 }
 
-#[bench]
-fn extend_vob_aligned(bench: &mut Bencher) {
+fn extend_vob_aligned(c: &mut Criterion) {
     // first initialise the source vector to drain
     let mut v1 = Vob::with_capacity(N);
     v1.extend((0..N).map(|i| i % 2 == 0));
 
-    bench.iter(|| {
-        let mut v2 = Vob::with_capacity(N);
-        v2.extend_from_vob(&v1)
+    c.bench_function("extend_vob_aligned", |b| {
+        b.iter(|| {
+            let mut v2 = Vob::with_capacity(N);
+            v2.extend_from_vob(&v1)
+        })
     });
 }
 
-#[bench]
-fn extend_vob_not_aligned(bench: &mut Bencher) {
+fn extend_vob_not_aligned(c: &mut Criterion) {
     // first initialise the source vector to drain
     let mut v1 = Vob::with_capacity(N);
     v1.extend((0..N).map(|i| i % 2 == 0));
 
-    bench.iter(|| {
-        let mut v2 = vob![true];
-        v2.extend_from_vob(&v1)
+    c.bench_function("extend_vob_not_aligned", |b| {
+        b.iter(|| {
+            let mut v2 = vob![true];
+            v2.extend_from_vob(&v1)
+        })
     });
 }
 
-#[bench]
-fn split_off(bench: &mut Bencher) {
+fn split_off(c: &mut Criterion) {
     let mut v1 = Vob::with_capacity(N);
     v1.extend((0..N).map(|i| i % 2 == 0));
 
-    bench.iter(|| {
-        let mut v2 = v1.clone();
-        v2.split_off(N / 2)
+    c.bench_function("split_off", |b| {
+        b.iter(|| {
+            let mut v2 = v1.clone();
+            v2.split_off(N / 2)
+        })
     });
 }
 
-#[bench]
-fn xor(bench: &mut Bencher) {
+fn xor(c: &mut Criterion) {
     let mut v1 = Vob::with_capacity(N);
     let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     v1.extend((0..N).map(|_| rng.gen::<bool>()));
     let mut v2 = Vob::with_capacity(N);
     v2.extend((0..N).map(|_| rng.gen::<bool>()));
 
-    bench.iter(|| {
-        v1.xor(&v2);
+    c.bench_function("xor", |b| {
+        b.iter(|| {
+            v1.xor(&v2);
+        })
     });
 }
 
-#[bench]
-fn or(bench: &mut Bencher) {
+fn or(c: &mut Criterion) {
     let mut v1 = Vob::with_capacity(N);
     let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     v1.extend((0..N).map(|_| rng.gen::<bool>()));
     let mut v2 = Vob::with_capacity(N);
     v2.extend((0..N).map(|_| rng.gen::<bool>()));
 
-    bench.iter(|| {
-        v1.or(&v2);
+    c.bench_function("or", |b| {
+        b.iter(|| {
+            v1.or(&v2);
+        })
     });
 }
 
-#[bench]
-fn and(bench: &mut Bencher) {
+fn and(c: &mut Criterion) {
     let mut v1 = Vob::with_capacity(N);
     let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     v1.extend((0..N).map(|_| rng.gen::<bool>()));
     let mut v2 = Vob::with_capacity(N);
     v2.extend((0..N).map(|_| rng.gen::<bool>()));
 
-    bench.iter(|| {
-        v1.and(&v2);
+    c.bench_function("and", |b| {
+        b.iter(|| {
+            v1.and(&v2);
+        })
     });
 }
 
-#[bench]
-fn from_bytes(bench: &mut Bencher) {
+fn from_bytes(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let mut v1 = [0u8; 1024];
     rng.fill(&mut v1);
-
-    bench.iter(|| Vob::from_bytes(&v1));
+    c.bench_function("from_bytes", |b| b.iter(|| Vob::from_bytes(&v1)));
 }
 
-#[bench]
-fn iter_set_bits(bench: &mut Bencher) {
+fn iter_set_bits(c: &mut Criterion) {
     let mut a = Vob::with_capacity(N);
     let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     a.extend((0..N).map(|_| rng.gen::<bool>()));
-    bench.iter(|| a.iter_set_bits(..).count());
+    c.bench_function("iter_set_bits", |b| b.iter(|| a.iter_set_bits(..).count()));
 }
 
-#[bench]
-fn iter_set_bits_u8(bench: &mut Bencher) {
+fn iter_set_bits_u8(c: &mut Criterion) {
     let mut a = Vob::<u8>::new_with_storage_type(N);
     let mut rng = Pcg64Mcg::seed_from_u64(RNG_SEED);
     a.extend((0..N).map(|_| rng.gen::<bool>()));
-    bench.iter(|| a.iter_set_bits(..).count());
+    c.bench_function("iter_set_bits_u8", |b| {
+        b.iter(|| a.iter_set_bits(..).count())
+    });
 }
 
-#[bench]
-fn iter_all_set_bits(bench: &mut Bencher) {
-    let a = Vob::from_elem(N, true);
-    bench.iter(|| a.iter_set_bits(..).count());
+fn iter_all_set_bits(c: &mut Criterion) {
+    let a = Vob::from_elem(true, N);
+    c.bench_function("iter_all_set_bits", |b| {
+        b.iter(|| a.iter_set_bits(..).count())
+    });
 }
 
-#[bench]
-fn iter_all_unset_bits(bench: &mut Bencher) {
-    let a = Vob::from_elem(N, true);
-    bench.iter(|| a.iter_unset_bits(..).count());
+fn iter_all_unset_bits(c: &mut Criterion) {
+    let a = Vob::from_elem(true, N);
+    c.bench_function("iter_all_unset_bits", |b| {
+        b.iter(|| a.iter_unset_bits(..).count())
+    });
 }
+
+criterion_group!(
+    benches,
+    empty,
+    extend,
+    extend_vob_aligned,
+    extend_vob_not_aligned,
+    split_off,
+    xor,
+    or,
+    and,
+    from_bytes,
+    iter_set_bits,
+    iter_set_bits_u8,
+    iter_all_set_bits,
+    iter_all_unset_bits
+);
+criterion_main!(benches);


### PR DESCRIPTION
`cargo bench` is still a nightly feature, which makes it easy not to notice that changes have broken benchmarking (my desktop, for example, exclusively runs stable).

This commit moves us from Rust's in-built benchmarking system to Criterion. This increases the boiler-plate but a) it works on stable (so we can now also test in CI!) b) it provides better statistical output.