### PR TITLE
Add optional bincode dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustc_version = "0.4"
 [dependencies]
 num-traits = "0.2.14"
 serde = { version="1.0", features=["derive"], optional=true }
+bincode = { version = "2.0", features=["derive"], optional=true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ use std::{
     slice,
 };
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 use num_traits::{PrimInt, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -89,6 +91,7 @@ use serde::{Deserialize, Serialize};
 /// `Vob`'s [`set_all(false)`](struct.Vob.html#method.set_all) function.
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub struct Vob<T = usize> {
     /// How many bits are stored in this Vob?
     len: usize,


### PR DESCRIPTION
bincode 2.0 has an alternative to the serde `Serialize`/`Deserialize` traits.  This patch adds an optional dependency and derives that trait.

* bincode serde is [optional](https://docs.rs/bincode/latest/bincode/#serde) 
* [Decode trait](https://docs.rs/bincode/latest/bincode/de/trait.Decode.html)
* [Encode trait](https://docs.rs/bincode/latest/bincode/enc/trait.Encode.html)

Also silences a rustc lint that appears to have changed between 1.37.0 and now.
I'm not exactly certain the compiler version that change happened in, so I used the version that I was running, I would imagine the warning probably was added a lot earlier though.