### PR TITLE
Remove unlicensed = deny, deny is the default behavior and was removed.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,4 @@
 [licenses]
-unlicensed = "deny"
 confidence-threshold = 1.0
 allow = [
     "Apache-2.0",


### PR DESCRIPTION

Seems that this caused the license check failure in #73